### PR TITLE
Replace print with logging

### DIFF
--- a/src/fatsecret_api.py
+++ b/src/fatsecret_api.py
@@ -7,6 +7,7 @@ import requests
 import random
 from urllib.parse import quote
 import config
+import logging
 
 def parse_weight(weight_str: str) -> float:
     weight_str = weight_str.replace("\u00A0", " ").lower().strip()
@@ -35,7 +36,7 @@ def parse_weight(weight_str: str) -> float:
     return 0.0
 
 def get_calcium_for_product(product_name: str, access_token: str, access_token_secret: str, product_weight: float = 100.0) -> float:
-    print(f"[DEBUG] Расчет кальция для продукта: {product_name}, масса: {product_weight} г")
+    logging.debug(f"Расчет кальция для продукта: {product_name}, масса: {product_weight} г")
     lower_name = product_name.lower()
     # Если продукт относится к альтернативному молоку или содержит слово "немолоко"
     alternative_keywords = ["кокос", "соев", "миндал", "овся", "рисов", "немолоко"]
@@ -58,5 +59,5 @@ def get_calcium_for_product(product_name: str, access_token: str, access_token_s
     else:
         base_calcium = 50.0
     calcium = base_calcium * (product_weight / 100.0)
-    print(f"[DEBUG] Для '{product_name}' с массой {product_weight} г возвращено значение кальция: {calcium:.2f} мг")
+    logging.debug(f"Для '{product_name}' с массой {product_weight} г возвращено значение кальция: {calcium:.2f} мг")
     return calcium

--- a/src/local_omega3_db.py
+++ b/src/local_omega3_db.py
@@ -1,4 +1,5 @@
 import csv
+import logging
 
 def load_local_omega3_db(file_path):
     """
@@ -16,7 +17,7 @@ def load_local_omega3_db(file_path):
                 cleaned_row = {k.strip(): v.strip() for k, v in row.items()}
                 data.append(cleaned_row)
     except Exception as e:
-        print(f"Ошибка загрузки локальной базы: {e}")
+        logging.debug(f"Ошибка загрузки локальной базы: {e}")
     return data
 
 def get_local_omega3(file_path):

--- a/src/product_filters.py
+++ b/src/product_filters.py
@@ -1,16 +1,19 @@
+import logging
+
+
 def filter_dairy_products(products, api_categories):
     dairy_products = []
     for product, weight, *rest in products:
-        print(f"[DEBUG] Обрабатываем продукт: {product} с массой {weight}")
+        logging.debug(f"Обрабатываем продукт: {product} с массой {weight}")
         dairy_class = classify_dairy_product(product, api_categories)
         if dairy_class:
             dairy_products.append((product, weight, dairy_class))
-    print(f"[DEBUG] Отфильтрованные молочные продукты: {dairy_products}")
+    logging.debug(f"Отфильтрованные молочные продукты: {dairy_products}")
     return dairy_products
 
 def classify_dairy_product(product_name, api_category=None):
     lower_name = product_name.lower()
-    print(f"[DEBUG] Проверяем название продукта: {product_name}, в нижнем регистре: {lower_name}")
+    logging.debug(f"Проверяем название продукта: {product_name}, в нижнем регистре: {lower_name}")
     
     # Сначала исключаем альтернативное молоко и продукты с "немолоко"
     alternative_keywords = ["кокос", "соев", "миндал", "овся", "рисов", "немолоко"]

--- a/src/vegetable_fruit_filters.py
+++ b/src/vegetable_fruit_filters.py
@@ -1,19 +1,20 @@
 from fatsecret_api import parse_weight
 import config
+import logging
 
 def filter_vegetable_and_fruit_products(products):
     vegetable_and_fruit_products = []
     for product, weight, *rest in products:
-        print(f"[DEBUG] Обрабатываем продукт: {product} с массой {weight}")
+        logging.debug(f"Обрабатываем продукт: {product} с массой {weight}")
         product_class = classify_vegetable_and_fruit_product(product)
         if product_class:
             vegetable_and_fruit_products.append((product, weight, product_class))
-    print(f"[DEBUG] Отфильтрованные растительные продукты: {vegetable_and_fruit_products}")
+    logging.debug(f"Отфильтрованные растительные продукты: {vegetable_and_fruit_products}")
     return vegetable_and_fruit_products
 
 def classify_vegetable_and_fruit_product(product_name):
     lower_name = product_name.lower()
-    print(f"[DEBUG] Проверяем название продукта: {product_name}, в нижнем регистре: {lower_name}")
+    logging.debug(f"Проверяем название продукта: {product_name}, в нижнем регистре: {lower_name}")
     
     dairy_exclusions = ["творог", "творожок", "сыр", "молоко", "кефир", "йогурт"]
     if any(dairy_kw in lower_name for dairy_kw in dairy_exclusions):
@@ -43,8 +44,8 @@ def handle_vegetables_and_fruits(products):
     for product, weight, product_class in plant_products:
         product_weight = parse_weight(weight)
         total_weight += product_weight
-        print(f"[DEBUG] Продукт: {product}, масса: {weight}")
-    print(f"[DEBUG] Общая масса растительной продукции: {total_weight:.2f} г")
+        logging.debug(f"Продукт: {product}, масса: {weight}")
+    logging.debug(f"Общая масса растительной продукции: {total_weight:.2f} г")
     
     if total_weight < 400:
         message = "Вы сильно не добираете растительности."


### PR DESCRIPTION
## Summary
- remove print statements from helper modules
- use `logging.debug` so debug info is emitted only when debug logging enabled
- import logging where necessary

## Testing
- `python -m py_compile src/local_omega3_db.py src/product_filters.py src/fatsecret_api.py src/vegetable_fruit_filters.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684356d166f4832089155c4233c0f824